### PR TITLE
Fixed the `Content.RssNewsArticles` method.

### DIFF
--- a/DotNetBungieAPI/Services/ApiAccess/ContentMethodsAccess.cs
+++ b/DotNetBungieAPI/Services/ApiAccess/ContentMethodsAccess.cs
@@ -120,7 +120,7 @@ internal sealed class ContentMethodsAccess : IContentMethodsAccess
     {
         var url = StringBuilderPool
             .GetBuilder(cancellationToken)
-            .Append("/Content/SearchContentByTagAndType/")
+            .Append("/Content/Rss/NewsArticles/")
             .AddUrlParam(pageToken)
             .Build();
         


### PR DESCRIPTION
The method was pointing to an incorrect endpoint, causing JSON parser errors to occur.